### PR TITLE
Add Google Sheets export for totals

### DIFF
--- a/Total calculation.html
+++ b/Total calculation.html
@@ -253,29 +253,28 @@
   }
 
   function saveTotalRecord() {
-    const saved = localStorage.getItem('totals');
-    if (saved) totals = JSON.parse(saved);
+    const tables = [
+      { table: document.getElementById('lunchTable'), unit: 'Total Lunch' },
+      { table: document.getElementById('dinnerTable'), unit: 'Total Dinner' }
+    ];
 
-    ['Lunch', 'Dinner'].forEach(meal => {
-      const mealData = totals[meal];
-      const unit = `Total ${meal}`;
-      for (const dateKey in mealData) {
-        const dateData = mealData[dateKey];
-        for (const level of levels) {
-          const row = dateData[level];
-          if (!row) continue;
-          const formData = new FormData();
-          formData.append('date', dateKey);
-          formData.append('unit', unit);
-          formData.append('diet_texture', level);
-          formData.append('soup', row[0]);
-          formData.append('meal1', row[1]);
-          formData.append('meal2', row[2]);
-          formData.append('vegetarian', row[3]);
-          formData.append('sideveg', row[4]);
-          formData.append('dessert', row[5]);
-          fetch(googleScriptURL, { method: 'POST', body: formData });
-        }
+    tables.forEach(({ table, unit }) => {
+      for (let i = 1; i < table.rows.length; i++) {
+        const cells = table.rows[i].cells;
+        if (cells.length < 8) continue;
+
+        const formData = new FormData();
+        formData.append('date', cells[0].innerText);
+        formData.append('unit', unit);
+        formData.append('diet_texture', cells[1].innerText);
+        formData.append('soup', cells[2].innerText);
+        formData.append('meal1', cells[3].innerText);
+        formData.append('meal2', cells[4].innerText);
+        formData.append('vegetarian', cells[5].innerText);
+        formData.append('sideveg', cells[6].innerText);
+        formData.append('dessert', cells[7].innerText);
+
+        fetch(googleScriptURL, { method: 'POST', body: formData });
       }
     });
   }


### PR DESCRIPTION
## Summary
- send the entire Total Lunch and Total Dinner tables to Google Sheets when Save Total Record is clicked

## Testing
- `python3 -m py_compile push_total_dinner.py sort_and_group.py`


------
https://chatgpt.com/codex/tasks/task_e_683fa03766f4832bb6cdb095f7776ece